### PR TITLE
feat: auto-run Alembic migrations on startup for PostgreSQL

### DIFF
--- a/apps/telegram-bot/Dockerfile
+++ b/apps/telegram-bot/Dockerfile
@@ -48,5 +48,6 @@ COPY packages/ /app/packages/
 COPY apps/telegram-bot/ /app/apps/telegram-bot/
 WORKDIR /app/apps/telegram-bot
 RUN mkdir -p /app/apps/telegram-bot/data
+RUN chmod +x /app/apps/telegram-bot/entrypoint.sh
 ENTRYPOINT ["/app/apps/telegram-bot/entrypoint.sh"]
 CMD ["python", "-m", "core.main"]

--- a/apps/telegram-bot/Dockerfile
+++ b/apps/telegram-bot/Dockerfile
@@ -48,4 +48,5 @@ COPY packages/ /app/packages/
 COPY apps/telegram-bot/ /app/apps/telegram-bot/
 WORKDIR /app/apps/telegram-bot
 RUN mkdir -p /app/apps/telegram-bot/data
+ENTRYPOINT ["/app/apps/telegram-bot/entrypoint.sh"]
 CMD ["python", "-m", "core.main"]

--- a/apps/telegram-bot/entrypoint.sh
+++ b/apps/telegram-bot/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # Run Alembic migrations if using PostgreSQL
 case "${SETTINGS_DATABASE_URL:-}" in
-  postgresql*)
+  postgresql*|postgres://*)
     echo "PostgreSQL detected, running migrations..."
     cd /app/packages/shared
     alembic upgrade head

--- a/apps/telegram-bot/entrypoint.sh
+++ b/apps/telegram-bot/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Run Alembic migrations if using PostgreSQL
+case "${SETTINGS_DATABASE_URL:-}" in
+  postgresql*)
+    echo "PostgreSQL detected, running migrations..."
+    cd /app/packages/shared
+    alembic upgrade head
+    cd /app/apps/telegram-bot
+    echo "Migrations complete."
+    ;;
+esac
+
+exec "$@"

--- a/apps/telegram-bot/pyproject.toml
+++ b/apps/telegram-bot/pyproject.toml
@@ -3,7 +3,7 @@ name = "fastfetchbot-telegram-bot"
 version = "0.1.0"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "fastfetchbot-shared[postgres]",
+    "fastfetchbot-shared[postgres,migrate]",
     "python-telegram-bot[callback-data,rate-limiter]>=21.11",
     "starlette>=0.45.0",
     "uvicorn>=0.34.2",

--- a/uv.lock
+++ b/uv.lock
@@ -895,7 +895,7 @@ source = { virtual = "apps/telegram-bot" }
 dependencies = [
     { name = "aiofiles" },
     { name = "beanie" },
-    { name = "fastfetchbot-shared", extra = ["postgres"] },
+    { name = "fastfetchbot-shared", extra = ["migrate", "postgres"] },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "python-telegram-bot", extra = ["callback-data", "rate-limiter"] },
@@ -907,7 +907,7 @@ dependencies = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "beanie", specifier = ">=1.29.0" },
-    { name = "fastfetchbot-shared", extras = ["postgres"], editable = "packages/shared" },
+    { name = "fastfetchbot-shared", extras = ["postgres", "migrate"], editable = "packages/shared" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "python-telegram-bot", extras = ["callback-data", "rate-limiter"], specifier = ">=21.11" },


### PR DESCRIPTION
## Summary
- Add entrypoint script to telegram-bot that runs `alembic upgrade head` when `SETTINGS_DATABASE_URL` is PostgreSQL, ensuring tables are created before the bot starts
- Add `migrate` optional extra to telegram-bot dependencies so `alembic` is available in the Docker image
- SQLite deployments are unaffected (entrypoint skips migrations)

## Test plan
- [ ] Build telegram-bot Docker image and verify entrypoint runs migrations against a PostgreSQL instance
- [ ] Verify SQLite mode still works (no migration step, tables auto-created)
- [ ] Verify idempotent re-runs (container restart doesn't fail on already-migrated DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Automated database migrations now execute automatically on application startup when PostgreSQL is configured.
  * Updated container initialization to handle database schema updates before starting the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->